### PR TITLE
Compress every message on the wire

### DIFF
--- a/proto/agent_message.proto
+++ b/proto/agent_message.proto
@@ -5,5 +5,9 @@ package agent_swarm;
 message AgentMessage {
     string sender_id = 1;
     int64 timestamp = 2;
+    // Always base64-encoded gzip(payload). Every message is compressed on the
+    // wire, so the receiver can decompress unconditionally without any sniffing.
     string content = 3;
+    // Byte length of the uncompressed payload, for receive-side verification.
+    int64 original_size = 4;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn test_agent_args_validation_empty_agent_id() {
         let args = AgentArgs {
-            agent_id: "".to_string(),
+            agent_id: String::new(),
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: None,
             llm_backend: LLMBackend::OpenAI,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,7 @@ async fn main() -> anyhow::Result<()> {
     let network_config = NetworkConfig {
         multicast_address: args.multicast_address,
         interface: args.interface.clone(),
-        buffer_size: 65536,          // 64KB buffer for better performance
-        compression_threshold: 1024, // Compress messages larger than 1KB
+        buffer_size: 65536, // 64KB buffer for better performance
     };
 
     // Initialize network manager

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,47 +10,58 @@ pub mod agent_message {
 
 pub use agent_message::AgentMessage;
 
-/// Compression utilities for message content
+/// Errors that can occur while (de)serializing an [`AgentMessage`].
+#[derive(Debug, thiserror::Error)]
+pub enum MessageError {
+    #[error("protobuf encode failed: {0}")]
+    Encode(#[from] prost::EncodeError),
+    #[error("protobuf decode failed: {0}")]
+    Decode(#[from] prost::DecodeError),
+    #[error("compression failed: {0}")]
+    Compress(#[source] std::io::Error),
+    #[error("decompression failed: {0}")]
+    Decompress(#[source] std::io::Error),
+    #[error("base64 decode failed: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("original size mismatch: expected {expected} bytes, decompressed to {actual}")]
+    SizeMismatch { expected: usize, actual: usize },
+}
+
+/// Compression utilities for message content.
+///
+/// Every message is compressed on the wire, so these helpers are the only path
+/// — there is no uncompressed variant.
 pub mod compression {
     use flate2::{Compression, write::GzEncoder};
     use std::io::Write;
     use tracing::debug;
 
-    /// Compress message content using gzip
-    pub fn compress_content(content: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        debug!("Compressing message");
+    /// Gzip-compress `content` into a new byte buffer.
+    pub fn compress_content(content: &str) -> Result<Vec<u8>, std::io::Error> {
+        debug!("Compressing {} bytes", content.len());
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(content.as_bytes())?;
-        Ok(encoder.finish()?)
+        encoder.finish()
     }
 
-    /// Decompress message content using gzip
-    pub fn decompress_content(
-        compressed_data: &[u8],
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    /// Gunzip `compressed_data` back into a UTF-8 string.
+    pub fn decompress_content(compressed_data: &[u8]) -> Result<String, std::io::Error> {
         use flate2::read::GzDecoder;
         use std::io::Read;
 
-        // Create a cursor to make the data readable
-        let cursor = std::io::Cursor::new(compressed_data);
-        let mut decoder = GzDecoder::new(cursor);
+        let mut decoder = GzDecoder::new(compressed_data);
         let mut decompressed_string = String::new();
         decoder.read_to_string(&mut decompressed_string)?;
 
-        debug!("Decompressed input to {decompressed_string}");
+        debug!("Decompressed to {decompressed_string}");
 
         Ok(decompressed_string)
-    }
-
-    /// Check if content should be compressed (if larger than threshold)
-    pub fn should_compress(content: &str, threshold: usize) -> bool {
-        content.len() > threshold
     }
 }
 
 impl AgentMessage {
-    /// Create a new `AgentMessage` with the current timestamp
+    /// Create a new `AgentMessage` with the current timestamp.
     pub fn new(sender_id: String, content: String) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -64,45 +75,56 @@ impl AgentMessage {
             sender_id,
             timestamp,
             content,
+            original_size: 0,
         }
     }
 
-    /// Create a compressed version of this message
-    pub fn to_compressed(
-        &self,
-        compression_threshold: usize,
-    ) -> Result<CompressedAgentMessage, Box<dyn std::error::Error>> {
-        if compression::should_compress(&self.content, compression_threshold) {
-            let compressed_data = compression::compress_content(&self.content)?;
-            Ok(CompressedAgentMessage {
-                sender_id: self.sender_id.clone(),
-                timestamp: self.timestamp,
-                compressed_data,
-                is_compressed: true,
-                original_size: self.content.len(),
-            })
-        } else {
-            // Return uncompressed version if below threshold
-            Ok(CompressedAgentMessage {
-                sender_id: self.sender_id.clone(),
-                timestamp: self.timestamp,
-                compressed_data: self.content.as_bytes().to_vec(),
-                is_compressed: false,
-                original_size: self.content.len(),
-            })
-        }
-    }
+    /// Serialize the message to wire bytes.
+    ///
+    /// The `content` field is **always** gzip-compressed and base64-encoded, so
+    /// the wire format is unambiguous: [`deserialize`](Self::deserialize) can
+    /// decompress unconditionally and never has to sniff or guess.
+    pub fn serialize(&self) -> Result<Vec<u8>, MessageError> {
+        let compressed =
+            compression::compress_content(&self.content).map_err(MessageError::Compress)?;
 
-    /// Serialize the message to bytes using protobuf
-    pub fn serialize(&self) -> Result<Vec<u8>, prost::EncodeError> {
+        let wire = AgentMessage {
+            sender_id: self.sender_id.clone(),
+            timestamp: self.timestamp,
+            content: STANDARD.encode(&compressed),
+            original_size: i64::try_from(self.content.len()).unwrap_or(i64::MAX),
+        };
+
         let mut buf = Vec::new();
-        self.encode(&mut buf)?;
+        wire.encode(&mut buf)?;
         Ok(buf)
     }
 
-    /// Deserialize bytes to `AgentMessage` using protobuf
-    pub fn deserialize(bytes: &[u8]) -> Result<Self, prost::DecodeError> {
-        Self::decode(bytes)
+    /// Deserialize wire bytes into a plaintext [`AgentMessage`].
+    ///
+    /// Reverses [`serialize`](Self::serialize): decode the protobuf, base64-decode
+    /// `content`, gunzip it, and verify the result against `original_size`.
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, MessageError> {
+        let wire = Self::decode(bytes)?;
+
+        let compressed = STANDARD.decode(&wire.content)?;
+        let content =
+            compression::decompress_content(&compressed).map_err(MessageError::Decompress)?;
+
+        let expected = usize::try_from(wire.original_size).unwrap_or_default();
+        if expected != 0 && content.len() != expected {
+            return Err(MessageError::SizeMismatch {
+                expected,
+                actual: content.len(),
+            });
+        }
+
+        Ok(Self {
+            sender_id: wire.sender_id,
+            timestamp: wire.timestamp,
+            content,
+            original_size: 0,
+        })
     }
 }
 
@@ -140,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_message_serialization_with_empty_content() {
-        let message = AgentMessage::new("agent-2".to_string(), "".to_string());
+        let message = AgentMessage::new("agent-2".to_string(), String::new());
 
         let serialized = message
             .serialize()
@@ -175,11 +197,12 @@ mod tests {
 
     #[test]
     fn test_message_with_custom_timestamp() {
-        let custom_timestamp = 1640995200; // Jan 1, 2022 00:00:00 UTC
+        let custom_timestamp = 1_640_995_200; // Jan 1, 2022 00:00:00 UTC
         let message = AgentMessage {
             sender_id: "agent-custom".to_string(),
             timestamp: custom_timestamp,
             content: "Custom timestamp test".to_string(),
+            original_size: 0,
         };
 
         let serialized = message
@@ -191,113 +214,60 @@ mod tests {
         assert_eq!(deserialized.timestamp, custom_timestamp);
     }
 
-    #[cfg(test)]
-    mod compression_tests {
-        use super::*;
+    #[test]
+    fn test_compression_round_trip() {
+        let original_content =
+            "This is a test message that should be compressed because it's quite long and exceeds the compression threshold for testing purposes. "
+                .repeat(10);
 
-        #[test]
-        fn test_compression_decompression() {
-            let original_content = "This is a test message that should be compressed because it's quite long and exceeds the compression threshold for testing purposes. ".repeat(10);
+        let compressed =
+            compression::compress_content(&original_content).expect("Failed to compress");
+        assert!(!compressed.is_empty());
+        assert!(compressed.len() < original_content.len());
 
-            // Test compression
-            let compressed =
-                compression::compress_content(&original_content).expect("Failed to compress");
-            assert!(!compressed.is_empty());
-            assert!(compressed.len() < original_content.len());
-
-            // Test decompression
-            let decompressed =
-                compression::decompress_content(&compressed).expect("Failed to decompress");
-            assert_eq!(decompressed, original_content);
-        }
-
-        #[test]
-        fn test_should_compress() {
-            assert!(!compression::should_compress("short", 100));
-            assert!(compression::should_compress(
-                "this is a longer message that exceeds the threshold",
-                50
-            ));
-        }
-
-        #[test]
-        fn test_compressed_agent_message() {
-            let original_message =
-                AgentMessage::new("test-agent".to_string(), "Test content".to_string());
-
-            // Test compression
-            let compressed_msg = original_message
-                .to_compressed(50)
-                .expect("Failed to create compressed message");
-            assert!(!compressed_msg.is_compressed);
-            assert_eq!(compressed_msg.original_size, 12);
-
-            // Test decompression back to regular message
-            let decompressed_msg = compressed_msg
-                .to_agent_message()
-                .expect("Failed to decompress message");
-            assert_eq!(decompressed_msg.sender_id, original_message.sender_id);
-            assert_eq!(decompressed_msg.content, original_message.content);
-        }
-
-        #[test]
-        fn test_uncompressed_agent_message() {
-            let original_message = AgentMessage::new("test-agent".to_string(), "Short".to_string());
-
-            // Test that short message is not compressed
-            let compressed_msg = original_message
-                .to_compressed(50)
-                .expect("Failed to create compressed message");
-            assert!(!compressed_msg.is_compressed);
-            assert_eq!(compressed_msg.original_size, 5);
-
-            // Test decompression back to regular message
-            let decompressed_msg = compressed_msg
-                .to_agent_message()
-                .expect("Failed to decompress message");
-            assert_eq!(decompressed_msg.content, original_message.content);
-        }
-    }
-}
-
-/// A message that can be either compressed or uncompressed
-pub struct CompressedAgentMessage {
-    pub sender_id: String,
-    pub timestamp: i64,
-    pub compressed_data: Vec<u8>,
-    pub is_compressed: bool,
-    pub original_size: usize,
-}
-
-impl CompressedAgentMessage {
-    /// Convert back to regular `AgentMessage` (decompress if needed)
-    pub fn to_agent_message(&self) -> Result<AgentMessage, Box<dyn std::error::Error>> {
-        let content = if self.is_compressed {
-            compression::decompress_content(&self.compressed_data)?
-        } else {
-            String::from_utf8(self.compressed_data.clone())?
-        };
-
-        Ok(AgentMessage {
-            sender_id: self.sender_id.clone(),
-            timestamp: self.timestamp,
-            content,
-        })
+        let decompressed =
+            compression::decompress_content(&compressed).expect("Failed to decompress");
+        assert_eq!(decompressed, original_content);
     }
 
-    /// Serialize the compressed message
-    pub fn serialize(&self) -> Result<Vec<u8>, prost::EncodeError> {
-        // Create a temporary AgentMessage for serialization
-        let temp_message = AgentMessage {
-            sender_id: self.sender_id.clone(),
-            timestamp: self.timestamp,
-            content: if self.is_compressed {
-                // Base64 encode compressed data for safe transmission
-                STANDARD.encode(&self.compressed_data)
-            } else {
-                String::from_utf8_lossy(&self.compressed_data).to_string()
-            },
+    #[test]
+    fn test_serialize_always_compresses_content() {
+        // Even a tiny message must be compressed on the wire — there is no
+        // uncompressed path anymore.
+        let message = AgentMessage::new("agent".to_string(), "tiny".to_string());
+
+        let serialized = message.serialize().expect("Failed to serialize");
+        let wire = String::from_utf8_lossy(&serialized);
+
+        assert!(
+            !wire.contains("tiny"),
+            "plaintext content must not appear on the wire"
+        );
+
+        // Round-trip still yields the original plaintext.
+        let back = AgentMessage::deserialize(&serialized).expect("Failed to deserialize");
+        assert_eq!(back.content, "tiny");
+        assert_eq!(back.sender_id, "agent");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_size_mismatch() {
+        // Build a valid wire message, then tamper with original_size to confirm
+        // the receive-side integrity check fires.
+        let message = AgentMessage::new("agent".to_string(), "hello world".to_string());
+        let wire_bytes = message.serialize().expect("serialize");
+        let wire = AgentMessage::decode(&wire_bytes[..]).expect("decode");
+
+        let tampered = AgentMessage {
+            sender_id: wire.sender_id,
+            timestamp: wire.timestamp,
+            content: wire.content,
+            original_size: wire.original_size + 1000,
         };
-        temp_message.serialize()
+        let mut bytes = Vec::new();
+        prost::Message::encode(&tampered, &mut bytes).expect("encode");
+
+        let result = AgentMessage::deserialize(&bytes);
+        assert!(matches!(result, Err(MessageError::SizeMismatch { .. })));
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,5 +1,4 @@
-use crate::message::{AgentMessage, CompressedAgentMessage};
-use base64::{Engine as _, engine::general_purpose::STANDARD};
+use crate::message::{AgentMessage, MessageError};
 use socket2::{Domain, Protocol, Socket, Type};
 use std::net::{Ipv4Addr, SocketAddr};
 
@@ -21,11 +20,8 @@ pub enum NetworkError {
     #[error("Failed to receive message: {0}")]
     ReceiveError(String),
 
-    #[error("Message serialization error: {0}")]
-    SerializationError(#[from] prost::EncodeError),
-
-    #[error("Message deserialization error: {0}")]
-    DeserializationError(#[from] prost::DecodeError),
+    #[error("Message (de)serialization error: {0}")]
+    Message(#[from] MessageError),
 
     #[error("Invalid network configuration: {0}")]
     ConfigError(String),
@@ -46,9 +42,6 @@ pub struct NetworkConfig {
     pub interface: Option<String>,
     /// Size of the receive buffer in bytes
     pub buffer_size: usize,
-    /// Message size threshold in bytes above which compression will be applied
-    /// Messages larger than this threshold will be compressed using gzip before transmission
-    pub compression_threshold: usize,
 }
 
 impl Default for NetworkConfig {
@@ -56,8 +49,7 @@ impl Default for NetworkConfig {
         Self {
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: None,
-            buffer_size: 65536,          // 64KB buffer
-            compression_threshold: 1024, // Compress messages larger than 1KB
+            buffer_size: 65536, // 64KB buffer
         }
     }
 }
@@ -176,28 +168,18 @@ impl NetworkManager {
 
     /// Send a message to the multicast group
     pub async fn send_message(&self, message: &AgentMessage) -> Result<(), NetworkError> {
-        // Convert to compressed message based on threshold
-        let compressed_message = message
-            .to_compressed(self.config.compression_threshold)
-            .map_err(|e| {
-                NetworkError::ConfigError(format!("Failed to compress message: {e}"))
-            })?;
-
-        // Serialize the compressed message using protobuf
-        let serialized = compressed_message
-            .serialize()
-            .map_err(NetworkError::SerializationError)?;
+        // serialize() always gzip-compresses + base64-encodes the content.
+        let serialized = message.serialize()?;
 
         // Send the serialized message to the multicast address
         match self.socket.send_to(&serialized, self.multicast_addr).await {
             Ok(bytes_sent) => {
                 tracing::debug!(
-                    "Sent {} bytes to multicast group {} from agent {} (compressed: {}, original size: {})",
+                    "Sent {} bytes to multicast group {} from agent {} (original size: {})",
                     bytes_sent,
                     self.multicast_addr,
                     self.agent_id,
-                    compressed_message.is_compressed,
-                    compressed_message.original_size
+                    message.content.len()
                 );
                 Ok(())
             }
@@ -245,34 +227,13 @@ impl NetworkManager {
         // shared buffer, no extra copies.
         let datagram = &buffer[..bytes_received];
 
-        // Single protobuf decode; the wire format is always `AgentMessage`,
-        // where `content` holds base64-encoded compressed bytes for messages
-        // above the compression threshold.
-        let wire_message = AgentMessage::deserialize(datagram).map_err(|e| {
-            let error_msg =
-                format!("Failed to deserialize message from {sender_addr}: {e}");
+        // Every message is compressed on the wire; deserialize handles
+        // base64-decode + gunzip + size verification deterministically.
+        let message = AgentMessage::deserialize(datagram).map_err(|e| {
+            let error_msg = format!("Failed to deserialize message from {sender_addr}: {e}");
             tracing::warn!("{}", error_msg);
-            NetworkError::DeserializationError(e)
+            NetworkError::Message(e)
         })?;
-
-        // Decode base64 + decompress if needed. The previous implementation
-        // sniffed content prefixes ("H4"/"eJ") which was fragile; instead try
-        // base64 decode + decompression and fall back to plain UTF-8 content.
-        let message = match STANDARD.decode(&wire_message.content) {
-            Ok(decoded) if !decoded.is_empty() => {
-                let compressed_message = CompressedAgentMessage {
-                    sender_id: wire_message.sender_id.clone(),
-                    timestamp: wire_message.timestamp,
-                    compressed_data: decoded,
-                    is_compressed: true,
-                    original_size: wire_message.content.len(),
-                };
-                compressed_message
-                    .to_agent_message()
-                    .unwrap_or(wire_message.clone())
-            }
-            _ => wire_message.clone(),
-        };
 
         tracing::debug!(
             "Successfully deserialized message from agent {} with content: '{}'",
@@ -294,7 +255,6 @@ mod tests {
         assert!(config.multicast_address.ip().is_multicast());
         assert_eq!(config.multicast_address.port(), 8080);
         assert_eq!(config.buffer_size, 65536);
-        assert_eq!(config.compression_threshold, 1024);
     }
 
     #[tokio::test]
@@ -303,7 +263,6 @@ mod tests {
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let result = NetworkManager::new(config, "test-agent".to_string());
@@ -316,7 +275,6 @@ mod tests {
             multicast_address: "192.168.1.1:8080".parse().unwrap(), // Not multicast
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let result = NetworkManager::new(config, "test-agent".to_string());
@@ -335,7 +293,6 @@ mod tests {
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let result = NetworkManager::create_multicast_socket(&config);
@@ -348,7 +305,6 @@ mod tests {
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: Some("127.0.0.1".to_string()),
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let result = NetworkManager::create_multicast_socket(&config);
@@ -373,7 +329,6 @@ mod tests {
             multicast_address: "239.255.255.250:8080".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let manager = NetworkManager::new(config, "test-sender".to_string()).unwrap();
@@ -392,12 +347,11 @@ mod tests {
             multicast_address: "239.255.255.250:8081".parse().unwrap(), // Different port
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let manager = NetworkManager::new(config, "test-sender-empty".to_string()).unwrap();
         let message =
-            crate::message::AgentMessage::new("test-sender-empty".to_string(), "".to_string());
+            crate::message::AgentMessage::new("test-sender-empty".to_string(), String::new());
 
         let result = manager.send_message(&message).await;
         assert!(result.is_ok());
@@ -409,7 +363,6 @@ mod tests {
             multicast_address: "239.255.255.250:8082".parse().unwrap(), // Different port
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let manager = NetworkManager::new(config, "test-sender-unicode".to_string()).unwrap();
@@ -428,7 +381,6 @@ mod tests {
             multicast_address: "239.255.255.250:8083".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         // Create sender and receiver
@@ -471,7 +423,6 @@ mod tests {
             multicast_address: "239.255.255.250:8084".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 1024,
         };
 
         let manager = NetworkManager::new(config, "test-malformed".to_string()).unwrap();
@@ -493,11 +444,8 @@ mod tests {
 
         // Should get a timeout or deserialization error
         match receive_result {
-            Ok(Err(NetworkError::DeserializationError(_))) => {
-                // This is expected for malformed data
-            }
-            Err(_) => {
-                // Timeout is also acceptable since malformed data might not be received
+            Ok(Err(NetworkError::Message(_))) | Err(_) => {
+                // Malformed data or receive timeout are both acceptable here.
             }
             _ => {
                 // Any other result is unexpected
@@ -512,7 +460,6 @@ mod tests {
             multicast_address: "239.255.255.250:8085".parse().unwrap(),
             interface: None,
             buffer_size: 1024,
-            compression_threshold: 100, // Low threshold to force compression
         };
 
         // Create sender and receiver
@@ -520,7 +467,7 @@ mod tests {
             NetworkManager::new(config.clone(), "test-sender-compress".to_string()).unwrap();
         let receiver = NetworkManager::new(config, "test-receiver-compress".to_string()).unwrap();
 
-        // Create a message that should be compressed (longer than threshold)
+        // Create a large message.
         let long_content = "This is a very long message that should definitely be compressed because it exceeds the compression threshold of 100 bytes. ".repeat(5);
         let test_message = crate::message::AgentMessage::new(
             "test-sender-compress".to_string(),
@@ -554,49 +501,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_no_compression_for_small_messages() {
+    async fn test_small_message_is_compressed_on_wire() {
         let config = NetworkConfig {
             multicast_address: "239.255.255.250:8086".parse().unwrap(),
             interface: None,
-            buffer_size: 1024,
-            compression_threshold: 1000, // High threshold to avoid compression
+            buffer_size: 4096,
         };
 
         // Create sender and receiver
-        let sender =
-            NetworkManager::new(config.clone(), "test-sender-no-compress".to_string()).unwrap();
-        let receiver =
-            NetworkManager::new(config, "test-receiver-no-compress".to_string()).unwrap();
+        let sender = NetworkManager::new(config.clone(), "sender".to_string()).unwrap();
+        let receiver = NetworkManager::new(config, "receiver".to_string()).unwrap();
 
-        // Create a short message that should not be compressed
-        let test_message = crate::message::AgentMessage::new(
-            "test-sender-no-compress".to_string(),
-            "Short message".to_string(),
-        );
+        // Small payload that, under the old threshold design, would have been
+        // sent uncompressed. With always-compress it must never appear as
+        // plaintext on the wire.
+        let plaintext = "PLAINTEXT_SECRET_42";
+        let test_message =
+            crate::message::AgentMessage::new("sender".to_string(), plaintext.to_string());
 
-        // Send message in a separate task
+        // Send and capture the raw datagram before it is decompressed.
         let send_message = test_message.clone();
         let send_task = tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
             sender.send_message(&send_message).await
         });
 
-        // Receive message with timeout
-        let receive_task = tokio::time::timeout(
+        let mut buf = vec![0u8; 4096];
+        let recv_task = tokio::time::timeout(
             tokio::time::Duration::from_secs(2),
-            receiver.receive_message(),
+            receiver.socket.recv_from(&mut buf),
         );
 
-        // Wait for both operations
-        let (send_result, receive_result) = tokio::join!(send_task, receive_task);
-
-        // Verify results
+        let (send_result, recv_result) = tokio::join!(send_task, recv_task);
         assert!(send_result.unwrap().is_ok());
-        assert!(receive_result.is_ok());
 
-        let received_message = receive_result.unwrap().unwrap();
-        assert_eq!(received_message.sender_id, test_message.sender_id);
-        assert_eq!(received_message.content, test_message.content);
-        assert_eq!(received_message.timestamp, test_message.timestamp);
+        let (n, _) = recv_result.unwrap().unwrap();
+        let datagram = String::from_utf8_lossy(&buf[..n]);
+        assert!(
+            !datagram.contains(plaintext),
+            "plaintext content must not appear on the wire, got: {datagram}"
+        );
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -148,7 +148,7 @@ impl Processor {
                             );
                         }
                     }
-                    Err(network::NetworkError::DeserializationError(e)) => {
+                    Err(network::NetworkError::Message(e)) => {
                         // Log malformed messages but continue processing
                         warn!("Received malformed message, skipping: {e}");
                     }


### PR DESCRIPTION
Closes #23.

## Problem
`CompressedAgentMessage` carried `is_compressed` / `original_size`, but `serialize()` collapsed everything into a plain `AgentMessage`, dropping the flag on the wire. The receiver therefore had to **guess**: every message paid a base64-decode + gunzip attempt, and the `unwrap_or(wire_message.clone())` fallback masked genuine corruption as valid plaintext. `original_size` was also mislabeled (it held the base64-string length, not the payload length).

## Fix (the "compress everything" approach)
Drop the compressed/uncompressed split entirely — the wire format is now **always** gzip+base64, so there is nothing to branch on and nothing to sniff.

- **`proto`**: add `int64 original_size` (field 4); `content` is always `base64(gzip(payload))`.
- **`message`**: fold compression into `serialize`/`deserialize`. `serialize()` always compresses and stamps `original_size`; `deserialize()` base64-decodes → gunzips → **verifies length against `original_size`** (corruption now errors instead of silently passing). Added a typed `MessageError`; deleted `CompressedAgentMessage`, `to_compressed`, `should_compress`, and the `is_compressed` flag.
- **`network`**: removed `compression_threshold` from `NetworkConfig`; `send_message`/`receive_message` are now single (de)serialize calls; collapsed the two `NetworkError` serialization/deserialization variants into one `Message(#[from] MessageError)`.
- **`processor`**: updated the intake-loop match to the new `NetworkError::Message` variant.

Net −255/+171 (more deleted than added).

## Verification
- `cargo build` ✅
- `cargo test` — **42/42 pass** ✅
- `cargo clippy --all-targets -- -Dclippy::pedantic` — **0 errors** ✅

New tests defend the contract:
- `test_serialize_always_compresses_content` — plaintext never appears on the wire, even for a 4-byte payload.
- `test_small_message_is_compressed_on_wire` — captures the raw multicast datagram and asserts the plaintext is absent (proves the old "small message sent uncompressed" path is gone).
- `test_deserialize_rejects_size_mismatch` — the receive-side integrity check fires on a tampered `original_size`.

> Note: the sandbox lacked the ALSA dev headers and the `protoc` binary, so those were provisioned under `/tmp` to build/test. Not part of the change.